### PR TITLE
Add settings to `customizations.vscode` in rust devcontainer

### DIFF
--- a/containers/rust/.devcontainer/devcontainer.json
+++ b/containers/rust/.devcontainer/devcontainer.json
@@ -22,6 +22,13 @@
   ],
   "customizations": {
     "vscode": {
+      "settings": {
+        "lldb.executable": "/usr/bin/lldb",
+        "files.watcherExclude": {
+          "**/target/**": true
+        },
+        "rust-analyzer.checkOnSave.command": "clippy"
+      },
       "extensions": [
         "rust-lang.rust-analyzer",
         "vadimcn.vscode-lldb",


### PR DESCRIPTION
It enables `lldb` and `clippy`.
